### PR TITLE
Two tabs to one space

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle})\" = ${qvalue}",
+          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle} | sed -e 's/\t/  /g')\" = ${qvalue}",
           command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle} | sed -e 's/\t/  /g')\" = ${qvalue}",
+          unless  => "/usr/bin/test \"$(/sbin/sysctl -n ${qtitle} | sed -e 's/\t/ /g')\" = ${qvalue}",
           command => "/sbin/sysctl -w ${qtitle}=${qvalue}",
       }
     }


### PR DESCRIPTION
Translating the tab from two characters to one character in the SED script supports more kernel parameters such as 'net.ipv4.ip_local_port_range'.